### PR TITLE
Fix local

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 3.7)
 
 project(grlBWT)
-
 set(CMAKE_CXX_STANDARD 17)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/")
@@ -10,36 +9,48 @@ find_package(LibSDSL REQUIRED)
 add_subdirectory(external/cdt)
 add_subdirectory(external/bioparsers)
 
-add_library(grlbwt
-            #OBJECT
-            lib/exact_algo/exact_ind_phase.cpp
-            lib/exact_algo/exact_par_phase.cpp
-            lib/opt_algo/opt_ind_phase.cpp
-            lib/opt_algo/opt_par_phase.cpp
-            external/malloc_count-master/malloc_count.c
-        )
+# Declare MALLOC_COUNT as an option
+option(MALLOC_COUNT "Compile grlBWT with malloc count (only for debugging purposes)" OFF)
+
+set(GRLBWT_LIB_FILES
+        lib/exact_algo/exact_ind_phase.cpp
+        lib/exact_algo/exact_par_phase.cpp
+        lib/opt_algo/opt_ind_phase.cpp
+        lib/opt_algo/opt_par_phase.cpp
+)
+
+#using malloc_count for monitoring memory usage during debug mode
+if(MALLOC_COUNT)
+    message(STATUS "Compiling with malloc count (only for debugging purposes)")
+    list(APPEND GRLBWT_LIB_FILES external/malloc_count-master/malloc_count.c)
+endif()
+
+add_library(grlbwt ${GRLBWT_LIB_FILES})
+
+if(MALLOC_COUNT)
+    target_compile_definitions(grlbwt PRIVATE USE_MALLOC_COUNT)
+endif()
 
 target_compile_options(grlbwt
         PRIVATE
         -Wall -Wextra -Wno-ignored-qualifiers -pedantic
         -O3 -funroll-loops -fomit-frame-pointer -ffast-math
         INTERFACE
-        -Wshadow)
+        -Wshadow
+)
 
 #compiler-dependent flags
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    message(STATUS "Disabling vla-extension due to ${CMAKE_CXX_COMPILER_ID}")
+    #message(STATUS "Disabling vla-extension due to ${CMAKE_CXX_COMPILER_ID}")
     target_compile_options(grlbwt PUBLIC -Wno-vla-extension -Wno-undefined-var-template)
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     message(STATUS "Adding -march=native compiler flag due to ${CMAKE_CXX_COMPILER_ID}")
     target_compile_options(grlbwt PUBLIC -march=native)
 endif()
 
-# there seems to be problem with the msse4.2 compiler flag and the new Apple chips
+#SSE instructions
 if(NOT CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "arm64")
     target_compile_options(grlbwt PUBLIC -msse4.2)
-else()
-    message(STATUS "Disabling SSE4.2 instructions due to conflict with host system processor ${CMAKE_HOST_SYSTEM_PROCESSOR}")
 endif()
 
 #for the file_system functionality on Linux
@@ -47,7 +58,7 @@ if(UNIX AND NOT APPLE)
     target_link_libraries(grlbwt LINK_PUBLIC stdc++fs)
 endif()
 
-target_link_libraries(grlbwt LINK_PUBLIC z pthread cdt dl)
+target_link_libraries(grlbwt LINK_PUBLIC z pthread cdt)
 
 target_include_directories(grlbwt
         PUBLIC
@@ -58,7 +69,14 @@ target_include_directories(grlbwt
         ${CMAKE_CURRENT_SOURCE_DIR}/external
         )
 
-target_include_directories(grlbwt SYSTEM PUBLIC ${LIBSDSL_INCLUDE_DIRS} external/malloc_count-master)
+target_include_directories(grlbwt SYSTEM PUBLIC ${LIBSDSL_INCLUDE_DIRS})
+
+#for malloc_count in debug mode
+if(MALLOC_COUNT)
+    target_link_libraries(grlbwt LINK_PUBLIC dl)
+    target_include_directories(grlbwt SYSTEM PUBLIC external/malloc_count-master)
+endif()
+
 add_executable(grlbwt-cli main.cpp)
 target_link_libraries(grlbwt-cli grlbwt biopar)
 target_include_directories(grlbwt-cli PUBLIC external/bioparsers/include)

--- a/external/bioparsers/CMakeLists.txt
+++ b/external/bioparsers/CMakeLists.txt
@@ -14,7 +14,7 @@ target_compile_options(biopar
         )
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    message(STATUS "Disabling vla-extension due to ${CMAKE_CXX_COMPILER_ID}")
+    #message(STATUS "Disabling vla-extension due to ${CMAKE_CXX_COMPILER_ID}")
     target_compile_options(biopar PUBLIC -Wno-vla-extension -Wno-undefined-var-template)
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     #message(STATUS "Adding -march=native compiler flag due to ${CMAKE_CXX_COMPILER_ID}")
@@ -26,8 +26,6 @@ target_link_libraries(biopar LINK_PUBLIC z cdt)
 # there seems to be problem with the msse4.2 compiler flag and the new Apple chips
 if(NOT CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "arm64")
     target_compile_options(biopar PUBLIC -msse4.2)
-else()
-    message(STATUS "Disabling SSE4.2 instructions due to conflict with host system processor ${CMAKE_HOST_SYSTEM_PROCESSOR}")
 endif()
 
 target_include_directories(biopar PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)

--- a/external/bioparsers/CMakeLists.txt
+++ b/external/bioparsers/CMakeLists.txt
@@ -9,7 +9,7 @@ add_library(biopar
 
 target_compile_options(biopar
         PUBLIC
-        -Wall -Wextra -Wno-ignored-qualifiers -pedantic -Wno-deprecated-copy -Wno-unused-function
+        -Wall -Wextra -Wno-ignored-qualifiers -pedantic $<$<COMPILE_LANGUAGE:CXX>:-Wno-deprecated-copy> -Wno-unused-function
         -O3 -funroll-loops -fomit-frame-pointer -ffast-math
         )
 

--- a/external/bioparsers/include/fastx_handler.h
+++ b/external/bioparsers/include/fastx_handler.h
@@ -151,9 +151,10 @@ hp_collection fasta_parser<is_gzipped>::operator()() {
     assert(j+1<read_bytes);
 
     p_sym = in_buffer[j++];
-    size_t r_len=1, n_hp=0, n_syms=0, max_hp=0, n_s_hp=0, max_n_s_hp=0;
+    size_t r_len=1, max_hp=0, n_s_hp=0, max_n_s_hp=0;
     hp_coll.str_coll.n_strings = 1;
     uint8_t r_head;
+    [[maybe_unused]] size_t n_hp=0, n_syms=0;
 
     while (read_bytes>0) {
         while(j<read_bytes){

--- a/external/cdt/CMakeLists.txt
+++ b/external/cdt/CMakeLists.txt
@@ -16,7 +16,7 @@ target_compile_options(cdt
 
 # this extra flags only applies to clang compilers
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    message(STATUS "Disabling vla-extension due to ${CMAKE_CXX_COMPILER_ID}")
+    #message(STATUS "Disabling vla-extension due to ${CMAKE_CXX_COMPILER_ID}")
     target_compile_options(cdt PUBLIC -Wno-vla-extension -Wno-undefined-var-template)
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     message(STATUS "Adding -march=native compiler flag due to ${CMAKE_CXX_COMPILER_ID}")
@@ -26,8 +26,6 @@ endif()
 # there seems to be problem with the msse4.2 compiler flag and the new Apple chips
 if(NOT CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "arm64")
     target_compile_options(cdt PUBLIC -msse4.2)
-else()
-    message(STATUS "Disabling SSE4.2 instructions due to conflict with host system processor ${CMAKE_HOST_SYSTEM_PROCESSOR}")
 endif()
 
 target_link_libraries(cdt LINK_PUBLIC ${LIBSDSL_LIBRARIES} z)

--- a/external/cdt/CMakeLists.txt
+++ b/external/cdt/CMakeLists.txt
@@ -10,7 +10,7 @@ add_library(cdt
 
 target_compile_options(cdt
         PUBLIC
-        -Wall -Wextra -Wno-ignored-qualifiers -pedantic -Wno-deprecated-copy -Wno-unused-function
+        -Wall -Wextra -Wno-ignored-qualifiers -pedantic $<$<COMPILE_LANGUAGE:CXX>:-Wno-deprecated-copy> -Wno-unused-function
         -O3 -funroll-loops -fomit-frame-pointer -ffast-math
         )
 

--- a/external/cdt/include/utils.h
+++ b/external/cdt/include/utils.h
@@ -115,11 +115,11 @@ void report_time(time_t start, time_t end, size_t padding){
 
     for(size_t i=0;i<padding;i++) std::cout<<" ";
     if(h.count()>0){
-        std::cout<<"Elapsed time (hh:mm:ss.ms): "<<h.count()<<":"<<m.count()<<":"<<s.count()<<"."<<ms.count()<<std::endl;
+        std::cout<<"Elapsed time (hh:mm:ss.ms): "<<std::setfill('0')<<std::setw(2)<<h.count()<<":"<<std::setfill('0')<<std::setw(2)<<m.count()<<":"<<std::setfill('0')<<std::setw(2)<<s.count()<<"."<<ms.count()<<std::endl;
     }else if(m.count()>0){
-        std::cout<<"Elapsed time (mm:ss.ms): "<<size_t(m.count())<<":"<<s.count()<<"."<<ms.count()<<std::endl;
+        std::cout<<"Elapsed time (mm:ss.ms): "<<std::setfill('0')<<std::setw(2)<<size_t(m.count())<<":"<<std::setfill('0')<<std::setw(2)<<s.count()<<"."<<ms.count()<<std::endl;
     }else if(s.count()>0){
-        std::cout<<"Elapsed time (ss.ms): "<<size_t(s.count())<<"."<<ms.count()<<std::endl;
+        std::cout<<"Elapsed time (ss.ms): "<<std::setfill('0')<<std::setw(2)<<size_t(s.count())<<"."<<ms.count()<<std::endl;
     }else{
         std::cout<<"Elapsed time (ms): "<<ms.count()<<std::endl;
     }

--- a/external/malloc_count-master/malloc_count.c
+++ b/external/malloc_count-master/malloc_count.c
@@ -328,7 +328,7 @@ static __attribute__((constructor)) void init(void)
 {
     char *error;
 
-    setlocale(LC_NUMERIC, ""); /* for better readable numbers */
+    //setlocale(LC_NUMERIC, ""); /* for better readable numbers */
 
     dlerror();
 

--- a/lib/exact_algo/exact_ind_phase.cpp
+++ b/lib/exact_algo/exact_ind_phase.cpp
@@ -4,10 +4,14 @@
 #include "exact_ind_phase.hpp"
 #include "bwt_io.h"
 #include <filesystem>
+
 #ifdef __linux__
 #include <malloc.h>
 #endif
+
+#ifdef USE_MALLOC_COUNT
 #include "malloc_count.h"
+#endif
 
 namespace exact_algo {
 
@@ -685,8 +689,10 @@ namespace exact_algo {
             }
             auto end = std::chrono::steady_clock::now();
             report_time(start, end, 4);
+#if USE_MALLOC_COUNT
             malloc_count_print_status();
             malloc_count_reset_peak();
+#endif
         }
     }
 

--- a/lib/exact_algo/exact_par_phase.cpp
+++ b/lib/exact_algo/exact_par_phase.cpp
@@ -5,7 +5,9 @@
 #include "exact_par_phase.hpp"
 #include "exact_LMS_induction.h"
 
+#ifdef USE_MALLOC_COUNT
 #include "malloc_count.h"
+#endif
 
 namespace exact_algo {
 
@@ -290,9 +292,9 @@ namespace exact_algo {
         std::cout<<"  Greatest symbol               : "<<str_coll.max_sym<<std::endl;
         std::cout<<"  Number of symbols in the file : "<<str_coll.n_syms<<std::endl;
         std::cout<<"  Number of strings             : "<<str_coll.n_strings<<std::endl;
-        if constexpr (std::is_same<uint8_t, sym_type>::value){
-            std::cout<<"  Max sym freq.                 : "<<str_coll.max_sym_freq<<std::endl;
-        }
+        //if constexpr (std::is_same<uint8_t, sym_type>::value){
+        //    std::cout<<"  Max sym freq.                 : "<<str_coll.max_sym_freq<<std::endl;
+        //}
 
         auto hbuff_size = std::max<size_t>(64 * n_threads, size_t(ceil(float(str_coll.n_syms) * hbuff_frac)));
 
@@ -328,8 +330,10 @@ namespace exact_algo {
         auto end = std::chrono::steady_clock::now();
 
         report_time(start, end, 4);
+#ifdef USE_MALLOC_COUNT
         malloc_count_print_status();
         malloc_count_reset_peak();
+#endif
 
         while (n_syms > 0) {
             start = std::chrono::steady_clock::now();
@@ -353,8 +357,12 @@ namespace exact_algo {
 
             remove(tmp_i_file.c_str());
             rename(output_file.c_str(), tmp_i_file.c_str());
+
+#ifdef USE_MALLOC_COUNT
             malloc_count_print_status();
             malloc_count_reset_peak();
+#endif
+
         }
 
         sdsl::util::clear(symbol_desc);

--- a/main.cpp
+++ b/main.cpp
@@ -3,7 +3,7 @@
 #include "CLI11.hpp"
 #include "utils.h"
 #include "grl_bwt.hpp"
-#include "fastx_handler.h"
+//#include "fastx_handler.h"
 
 struct arguments{
     std::string input_file;
@@ -61,8 +61,7 @@ static void parse_app(CLI::App& app, struct arguments& args){
                       "Maximum number of working threads")->default_val(1);
     app.add_option("-f,--hbuff",
                       args.hbuff_frac,
-                      "Hashing step will use at most INPUT_SIZE*f bytes. O means no limit (def. 0.5)")->
-            check(CLI::Range(0.0,1.0))->default_val(0.15);
+                      "Hashing step will use at most INPUT_SIZE*f bytes. O means no limit (def. 0.5)")->check(CLI::Range(0.0,1.0))->default_val(0.15);
     app.add_option("-b,--run-len-bytes",
                    args.b_f_r,
                    "Max. number of bytes to encode the run lengths in the recursive BWTs (def. 1)")->
@@ -75,8 +74,7 @@ static void parse_app(CLI::App& app, struct arguments& args){
                  args.ver, "Print the software version and exit");
     //app.add_flag("-R,--rev-comp", args.rev_comp, "Also consider the DNA reverse complements of the strings in TEXT");
     //app.add_flag("-m,--min-bwt", args.opt_bwt, "Produce the optimal BCR BWT instead of the regular one");
-
-    app.footer("Report bugs to <diego.diaz@helsinki.fi>");
+    //app.footer("Report bugs to <diego.diaz@helsinki.fi>");
 }
 
 template<class sym_type>

--- a/scripts/split_runs.cpp
+++ b/scripts/split_runs.cpp
@@ -132,7 +132,7 @@ int main(int argc, char** argv) {
     size_t q1=(tot_blocks+1)/4;
     size_t q2 = (tot_blocks+1)/2;
     size_t q3 = (3*(tot_blocks+1))/4;
-    size_t res1=0, res2, res3;
+    size_t res1=0, res2=0, res3=0;
     bool b_q1=false, b_q2=false, b_q3=false;
     size_t block_acc=0;
     std::string output_dist_file = output_file+".dist";


### PR DESCRIPTION
There was a minor incongruence between locale and CLI generated by `malloc_count`, which is now fixed. The library `malloc_count` is only for debugging purposes. Now, it has to be enabled during compilation time as `cmake -DMALLOC_COUNT=on ../`