### PR TITLE
Fix compiler errors related to missing uint8_t / uint16_t definitions

### DIFF
--- a/external/bioparsers/include/dna_string.h
+++ b/external/bioparsers/include/dna_string.h
@@ -10,6 +10,7 @@
 #include <vector>
 #include <iostream>
 #include <algorithm>
+#include <cstdint>
 
 class dna_string : public std::basic_string<uint8_t> {
 private:

--- a/include/bwt_io.h
+++ b/include/bwt_io.h
@@ -10,6 +10,7 @@
 #include <functional>
 #include <cstring>
 #include <cassert>
+#include <cstdint>
 
 class bwt_buff_reader {
 


### PR DESCRIPTION
Hi Diego -- I think this fix was necessary to get grlBWT to compile in a debian Linux environment with gcc 13.3.0.

More environment details:

```
$ gcc --version
gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
Copyright (C) 2023 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

$ uname -a
Linux 22c10af077d9 6.12.54-linuxkit #1 SMP Fri Nov 21 10:33:45 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux

$ cat /etc/issue
Ubuntu 24.04.3 LTS \n \l
```

Thanks for this great software!
Ben